### PR TITLE
Add Intercom Insights dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+INTERCOM_TOKEN=your_intercom_pat
+OPENAI_API_KEY=your_openai_key_optional
+APP_ID=your_intercom_app_id

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# intercom_dash
-dashboard for intercom conversations
+# Intercom Insights
+
+A Flask and Plotly Dash dashboard for analysing Intercom conversations.
+
+## Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # edit with your credentials
+flask run
+```
+
+## Testing
+
+```bash
+pytest
+```
+
+The app schedules a nightly job to refresh Intercom data.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+"""Flask entry point for Intercom Insights."""
+from flask import Flask
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from etl import sync_conversations
+from dash_layout import build_dash
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(sync_conversations, 'cron', hour=0)
+    scheduler.start()
+
+    build_dash(app)
+    return app
+
+
+app = create_app()
+
+if __name__ == '__main__':
+    sync_conversations()
+    app.run(debug=True)

--- a/dash_layout.py
+++ b/dash_layout.py
@@ -1,0 +1,85 @@
+"""Dash app layout and callbacks."""
+import yaml
+import pandas as pd
+import dash
+from dash import html, dcc, dash_table
+import plotly.express as px
+from datetime import datetime
+
+from etl import load_conversations
+
+
+def load_theme_mapping(path='themes.yml'):
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    mapping = {}
+    for theme, keywords in data.items():
+        for kw in keywords:
+            mapping[kw.lower()] = theme
+    return mapping
+
+
+def categorize_themes(df: pd.DataFrame, mapping: dict) -> pd.DataFrame:
+    df = df.copy()
+    themes = []
+    for body in df['body'].fillna(''):
+        found = None
+        low = body.lower()
+        for kw, theme in mapping.items():
+            if kw in low:
+                found = theme
+                break
+        themes.append(found or 'other')
+    df['theme'] = themes
+    return df
+
+
+def detect_sales(df: pd.DataFrame, keywords_path='sales_keywords.yml') -> pd.DataFrame:
+    with open(keywords_path) as f:
+        kws = [k.lower() for k in yaml.safe_load(f)]
+    df = df.copy()
+    df['is_sales'] = df['tags'].apply(lambda tags: bool(set(tags) & {'sales'}))
+    def kw_match(text):
+        t = text.lower()
+        return any(kw in t for kw in kws)
+    df.loc[~df['is_sales'], 'is_sales'] = df['body'].fillna('').apply(kw_match)
+    return df
+
+
+def build_dash(server):
+    df = load_conversations()
+    mapping = load_theme_mapping()
+    df = categorize_themes(df, mapping)
+    df = detect_sales(df)
+
+    volume = df.groupby(df['created_at'].dt.date).size().reset_index(name='count')
+    fig_volume = px.line(volume, x='created_at', y='count', title='Conversations per day')
+
+    sales_share = df['is_sales'].mean()*100 if not df.empty else 0
+
+    app = dash.Dash(server=server, title="Intercom Insights", external_stylesheets=[
+        'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css'
+    ])
+
+    app.layout = html.Div([
+        dcc.Tabs([
+            dcc.Tab(label='Overview', children=[
+                html.H3(f"Sales share: {sales_share:.1f}%"),
+                dcc.Graph(figure=fig_volume)
+            ]),
+            dcc.Tab(label='Themes', children=[
+                dcc.Graph(figure=px.bar(df, x='theme', y=None, title='Theme counts')),
+            ]),
+            dcc.Tab(label='Team', children=[
+                dash_table.DataTable(data=df.groupby(['assignee_name']).size().reset_index(name='count').to_dict('records'),
+                                     columns=[{'name':'Assignee','id':'assignee_name'}, {'name':'Conversations','id':'count'}])
+            ]),
+            dcc.Tab(label='Drill-down', children=[
+                dash_table.DataTable(
+                    data=df.to_dict('records'),
+                    columns=[{"name": i, "id": i, "presentation": 'markdown' if i=='conversation_url' else None} for i in df.columns]
+                )
+            ])
+        ])
+    ])
+    return app

--- a/etl.py
+++ b/etl.py
@@ -1,0 +1,47 @@
+"""ETL utilities for Intercom Insights."""
+import pandas as pd
+from typing import List, Dict, Any
+
+from models import SessionLocal, Conversation
+from intercom_client import fetch_conversations_months
+
+
+def sync_conversations(months: int = 12) -> int:
+    """Fetch conversations and persist raw JSON to SQLite.
+
+    Returns number of new conversations stored."""
+    session = SessionLocal()
+    new = 0
+    for conv in fetch_conversations_months(months):
+        if not session.get(Conversation, conv['id']):
+            session.add(Conversation(id=conv['id'], data=conv))
+            new += 1
+    session.commit()
+    session.close()
+    return new
+
+
+def flatten(conv: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten raw conversation JSON for analytics."""
+    first_msg = conv.get('source', {}).get('body', '')
+    assignee = conv.get('assignee', {}) or {}
+    return {
+        'id': conv.get('id'),
+        'created_at': pd.to_datetime(conv.get('created_at'), unit='s'),
+        'updated_at': pd.to_datetime(conv.get('updated_at'), unit='s'),
+        'assignee_id': assignee.get('id'),
+        'assignee_name': assignee.get('name'),
+        'tags': [t.get('name') for t in conv.get('tags', {}).get('tags', [])],
+        'subject': conv.get('title'),
+        'body': first_msg,
+        'conversation_url': conv.get('conversation_url'),
+    }
+
+
+def load_conversations() -> pd.DataFrame:
+    """Load stored conversations as DataFrame."""
+    session = SessionLocal()
+    rows = session.query(Conversation).all()
+    session.close()
+    data = [flatten(r.data) for r in rows]
+    return pd.DataFrame(data)

--- a/intercom_client.py
+++ b/intercom_client.py
@@ -1,0 +1,40 @@
+import os
+import time
+from datetime import datetime, timedelta
+from typing import Generator, Dict, Any
+
+import requests
+
+BASE_URL = 'https://api.intercom.io'
+TOKEN = os.getenv('INTERCOM_TOKEN')
+APP_ID = os.getenv('APP_ID')
+
+HEADERS = {
+    'Authorization': f'Bearer {TOKEN}',
+    'Accept': 'application/json',
+    'User-Agent': 'intercom-insights/1.0'
+}
+
+def fetch_conversations_months(months: int = 12) -> Generator[Dict[str, Any], None, None]:
+    """Yield conversations from the last `months` months."""
+    since = int((datetime.utcnow() - timedelta(days=30*months)).timestamp())
+    url = f"{BASE_URL}/conversations"
+    params = {'per_page': 50, 'sort': 'created_at', 'order': 'desc'}
+
+    while url:
+        resp = requests.get(url, headers=HEADERS, params=params)
+        if resp.status_code == 429:
+            reset = int(resp.headers.get('X-RateLimit-Reset', '1'))
+            time.sleep(reset)
+            continue
+        resp.raise_for_status()
+        data = resp.json()
+        for conv in data.get('conversations', []):
+            if conv.get('created_at', 0) >= since:
+                conv['conversation_url'] = (
+                    f"https://app.intercom.com/a/apps/{APP_ID}/inbox/inbox/all/conversations/{conv['id']}"
+                )
+                yield conv
+        url = data.get('pages', {}).get('next')
+        params = None  # next already encoded in URL
+        time.sleep(0.5)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,23 @@
+from sqlalchemy import create_engine, Column, Integer, DateTime, JSON
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime
+import os
+
+Base = declarative_base()
+
+class Conversation(Base):
+    __tablename__ = 'conversations'
+    id = Column(Integer, primary_key=True)
+    data = Column(JSON)
+    fetched_at = Column(DateTime, default=datetime.utcnow)
+
+def get_engine(db_path=None):
+    db_path = db_path or os.path.join('data', 'intercom.db')
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    return create_engine(f'sqlite:///{db_path}', connect_args={'check_same_thread': False})
+
+engine = get_engine()
+SessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(engine)
+SessionLocal.configure(bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+Flask
+Dash
+plotly
+pandas
+SQLAlchemy
+requests
+python-dotenv
+apscheduler
+pyyaml
+openai
+pytest

--- a/sales_keywords.yml
+++ b/sales_keywords.yml
@@ -1,0 +1,4 @@
+- deal
+- quote
+- pricing
+- purchase

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,0 +1,20 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from etl import flatten
+
+sample_conv = {
+    'id': 1,
+    'created_at': 0,
+    'updated_at': 0,
+    'assignee': {'id': 2, 'name': 'Kris'},
+    'tags': {'tags': [{'name': 'sales'}]},
+    'title': 'Hello',
+    'source': {'body': 'Need a quote'},
+    'conversation_url': 'http://example.com'
+}
+
+def test_flatten_basic():
+    data = flatten(sample_conv)
+    assert data['assignee_name'] == 'Kris'
+    assert data['tags'] == ['sales']
+    assert data['subject'] == 'Hello'

--- a/themes.yml
+++ b/themes.yml
@@ -1,0 +1,4 @@
+bug: ["error", "bug", "issue"]
+billing: ["invoice", "payment", "billing"]
+feature request: ["feature", "request", "improvement"]
+sales: ["pricing", "quote", "purchase"]


### PR DESCRIPTION
## Summary
- build Flask/Dash dashboard for Intercom data
- add ETL utilities and Intercom client
- schedule nightly sync job
- include sample environment file and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f3a5a7f483269d5756125eedc401